### PR TITLE
Exit the process when everything should be done.

### DIFF
--- a/ts/src/node/cli-main.ts
+++ b/ts/src/node/cli-main.ts
@@ -707,7 +707,7 @@ async function main() {
 
 main()
   .then(() => {
-    // console.log("done");
+    process.exit(0);
   })
   .catch(e => {
     console.log(e.stack);


### PR DESCRIPTION
This would resolve #7 

The fatal block uses process.exit, and the success condition could use it as well.

Figuring out what is preventing a clean exit here would be better, but considering how many issues there have been around it hanging, this may help reduce false-positives.